### PR TITLE
fix(web): Use process child method to kill server

### DIFF
--- a/apps/web/src-tauri/src/main.rs
+++ b/apps/web/src-tauri/src/main.rs
@@ -1,6 +1,14 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-use tauri_plugin_shell::ShellExt;
+
+use std::sync::Mutex;
+
+use tauri::Manager;
+use tauri_plugin_shell::{process::CommandChild, ShellExt};
+
+struct ApplicationState {
+    server_process: Option<CommandChild>,
+}
 
 fn main() {
     tauri::Builder::default()
@@ -8,35 +16,30 @@ fn main() {
         .invoke_handler(tauri::generate_handler![])
         .setup(|app| {
             let sidecar_command = app.shell().sidecar("audioling-server").unwrap();
-            let (_rx, _child) = sidecar_command
+            let (_rx, child) = sidecar_command
                 .env("NODE_ENV", "production")
                 .spawn()
                 .expect("Failed to spawn audioling-server");
-
+            app.manage(Mutex::new(ApplicationState {
+                server_process: Some(child),
+            }));
             Ok(())
         })
-        .on_window_event(|_event_window, event| {
+        .on_window_event(|event_window, event| {
             if let tauri::WindowEvent::Destroyed = event {
-                #[cfg(target_os = "windows")]
+                if let Ok(mut state) = event_window
+                    .app_handle()
+                    .state::<Mutex<ApplicationState>>()
+                    .lock()
                 {
-                    use std::process::Command;
-                    use std::os::windows::process::CommandExt;
-
-                    const CREATE_NO_WINDOW: u32 = 0x08000000;
-                    Command::new("taskkill")
-                        .args(["/F", "/IM", "audioling-server.exe"])
-                        .creation_flags(CREATE_NO_WINDOW)
-                        .output()
-                        .expect("Failed to kill audioling-server process");
-                }
-
-                #[cfg(not(target_os = "windows"))]
-                {
-                    use std::process::Command;
-                    Command::new("pkill")
-                        .arg("audioling-server")
-                        .output()
-                        .expect("Failed to kill audioling-server process");
+                    let child = state.server_process.take();
+                    if let Some(child) = child {
+                        if let Err(e) = child.kill() {
+                            eprintln!("failed to kill server: {e}");
+                        } else {
+                            println!("killed server");
+                        }
+                    }
                 }
             }
         })


### PR DESCRIPTION
Replaces usage of shell commands to kill server, with the methods provided tauri to kill sidecar process children.